### PR TITLE
Fix font glyph artifacts by switching to opentype

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -99,6 +99,15 @@ bool fetchAndDisplay() {
     return true;
 }
 
+void displaySplash() {
+    size_t jpg_len = wp_jpg_end - wp_jpg_start;
+    Serial.printf("Displaying splash image (%d bytes)\n", jpg_len);
+    canvas.createCanvas(960, 540);
+    canvas.drawJpg(wp_jpg_start, jpg_len, 0, 0);
+    canvas.pushCanvas(0, 0, UPDATE_MODE_GC16);
+    delay(5000);
+}
+
 void drawBatteryBar() {
     uint32_t voltage = M5.getBatteryVoltage();
     int percent = (voltage - 3200) * 100 / (4200 - 3200);

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
 	github.com/fogleman/gg v1.3.0
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	golang.org/x/image v0.38.0
 )
 
@@ -29,5 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	golang.org/x/text v0.35.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,5 +50,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
 golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/render/dam_panel.go
+++ b/internal/render/dam_panel.go
@@ -18,21 +18,23 @@ func drawDamHeader(dc *gg.Context, now time.Time, dam *DamData) {
 	// Dam name (left)
 	face := fontFace(fontRegular, 22)
 	dc.SetFontFace(face)
-	dc.DrawStringAnchored("宇連ダム貯水率", float64(marginX), float64(headerHeight)/2, 0, 0.5)
+	baselineY := centeredBaselineY(face, float64(headerHeight)/2)
+
+	dc.DrawStringAnchored("宇連ダム貯水率", float64(marginX), baselineY, 0, 0)
 
 	// Date and time (center-right)
 	dateStr := fmt.Sprintf("%d年%d月%d日(%s) %s",
 		now.Year(), now.Month(), now.Day(), weekdayJP[now.Weekday()],
 		now.Format("15:04"))
-	dc.DrawStringAnchored(dateStr, float64(Width-marginX), float64(headerHeight)/2, 1, 0.5)
+	dc.DrawStringAnchored(dateStr, float64(Width-marginX), baselineY, 1, 0)
 
-	// Observation time (right, smaller)
+	// Observation time (center, smaller — same baseline)
 	if dam != nil {
 		face2 := fontFace(fontRegular, 14)
 		dc.SetFontFace(face2)
 		dc.SetRGB(0.4, 0.4, 0.4)
 		obsStr := fmt.Sprintf("観測: %s", dam.ObservedAt.Format("01/02 15:04"))
-		dc.DrawStringAnchored(obsStr, float64(Width/2), float64(headerHeight)/2, 0.5, 0.5)
+		dc.DrawStringAnchored(obsStr, float64(Width/2), baselineY, 0.5, 0)
 	}
 }
 
@@ -44,20 +46,20 @@ func drawStorageRate(dc *gg.Context, dam *DamData) {
 	dc.SetRGB(0, 0, 0)
 	face := fontFace(fontRegular, 20)
 	dc.SetFontFace(face)
-	dc.DrawStringAnchored("現在の貯水率は", centerX, baseY+50, 0.5, 0.5)
+	dc.DrawStringAnchored("現在の貯水率は", centerX, centeredBaselineY(face, baseY+50), 0.5, 0)
 
 	// Large percentage number
 	rateStr := fmt.Sprintf("%.1f%%", dam.StorageRate)
 	faceLarge := fontFace(fontRegular, 80)
 	dc.SetFontFace(faceLarge)
-	dc.DrawStringAnchored(rateStr, centerX, baseY+150, 0.5, 0.5)
+	dc.DrawStringAnchored(rateStr, centerX, centeredBaselineY(faceLarge, baseY+150), 0.5, 0)
 
 	// Storage volume below
 	face3 := fontFace(fontRegular, 16)
 	dc.SetFontFace(face3)
 	dc.SetRGB(0.3, 0.3, 0.3)
 	volStr := fmt.Sprintf("(%.0f / 28,420 千m³)", dam.EffectiveStorage)
-	dc.DrawStringAnchored(volStr, centerX, baseY+210, 0.5, 0.5)
+	dc.DrawStringAnchored(volStr, centerX, centeredBaselineY(face3, baseY+210), 0.5, 0)
 }
 
 func drawYearlyChart(dc *gg.Context, now time.Time, history map[string][]DailyStorageRate) {
@@ -76,7 +78,7 @@ func drawYearlyChart(dc *gg.Context, now time.Time, history map[string][]DailySt
 	dc.SetRGB(0, 0, 0)
 	face := fontFace(fontRegular, 14)
 	dc.SetFontFace(face)
-	dc.DrawStringAnchored("年間貯水率 (%)", chartLeft+chartWidth/2, float64(mainY)+12, 0.5, 0.5)
+	dc.DrawStringAnchored("年間貯水率 (%)", chartLeft+chartWidth/2, centeredBaselineY(face, float64(mainY)+12), 0.5, 0)
 
 	// Draw axes
 	dc.SetRGB(0, 0, 0)
@@ -91,7 +93,7 @@ func drawYearlyChart(dc *gg.Context, now time.Time, history map[string][]DailySt
 	dc.SetRGB(0.4, 0.4, 0.4)
 	for _, pct := range []float64{0, 25, 50, 75, 100} {
 		y := chartBottom - (pct/100)*chartHeight
-		dc.DrawStringAnchored(fmt.Sprintf("%.0f", pct), chartLeft-5, y, 1, 0.5)
+		dc.DrawStringAnchored(fmt.Sprintf("%.0f", pct), chartLeft-5, centeredBaselineY(faceSmall, y), 1, 0)
 		// Grid line
 		if pct > 0 && pct < 100 {
 			dc.SetRGB(0.85, 0.85, 0.85)
@@ -199,7 +201,7 @@ func drawYearlyChart(dc *gg.Context, now time.Time, history map[string][]DailySt
 		}
 		dc.Stroke()
 		dc.SetFontFace(faceSmall)
-		dc.DrawStringAnchored(yearKey, legendX+25, legendY, 0, 0.5)
+		dc.DrawStringAnchored(yearKey, legendX+25, centeredBaselineY(faceSmall, legendY), 0, 0)
 	}
 }
 
@@ -276,9 +278,9 @@ func drawHourlyDelta(dc *gg.Context, history []DamObservation) {
 	baseY := float64(hourlyDeltaY) + 10
 
 	dc.SetRGB(0, 0, 0)
-	face := fontFace(fontRegular, 14)
-	dc.SetFontFace(face)
-	dc.DrawStringAnchored("24時間の貯水量変化 (千m³)", float64(marginX), baseY+8, 0, 0.5)
+	faceTitle := fontFace(fontRegular, 14)
+	dc.SetFontFace(faceTitle)
+	dc.DrawStringAnchored("24時間の貯水量変化 (千m³)", float64(marginX), centeredBaselineY(faceTitle, baseY+8), 0, 0)
 
 	// Calculate deltas between consecutive observations
 	type delta struct {
@@ -314,6 +316,9 @@ func drawHourlyDelta(dc *gg.Context, history []DamObservation) {
 	colWidth := availWidth / float64(colCount)
 
 	faceLabel := fontFace(fontRegular, 20)
+	blRow1 := centeredBaselineY(faceLabel, baseY+38)
+	blRow2 := centeredBaselineY(faceLabel, baseY+68)
+	blRow3 := centeredBaselineY(faceLabel, baseY+98)
 
 	for i := 0; i < colCount; i++ {
 		d := deltas[i]
@@ -322,7 +327,7 @@ func drawHourlyDelta(dc *gg.Context, history []DamObservation) {
 		// Time label
 		dc.SetRGB(0.3, 0.3, 0.3)
 		dc.SetFontFace(faceLabel)
-		dc.DrawStringAnchored(d.timeStr, x, baseY+38, 0.5, 0.5)
+		dc.DrawStringAnchored(d.timeStr, x, blRow1, 0.5, 0)
 
 		// Delta value with color coding
 		var diffStr string
@@ -335,12 +340,12 @@ func drawHourlyDelta(dc *gg.Context, history []DamObservation) {
 		}
 
 		dc.SetFontFace(faceLabel)
-		dc.DrawStringAnchored(diffStr, x, baseY+68, 0.5, 0.5)
+		dc.DrawStringAnchored(diffStr, x, blRow2, 0.5, 0)
 
 		// Storage rate
 		dc.SetRGB(0.3, 0.3, 0.3)
 		dc.SetFontFace(faceLabel)
-		dc.DrawStringAnchored(fmt.Sprintf("%.1f%%", d.rate), x, baseY+98, 0.5, 0.5)
+		dc.DrawStringAnchored(fmt.Sprintf("%.1f%%", d.rate), x, blRow3, 0.5, 0)
 	}
 
 	// Column separators
@@ -355,13 +360,13 @@ func drawHourlyDelta(dc *gg.Context, history []DamObservation) {
 	// Row labels
 	dc.SetRGB(0.5, 0.5, 0.5)
 	dc.SetFontFace(faceLabel)
-	dc.DrawStringAnchored("時刻", float64(marginX)-2, baseY+38, 1, 0.5)
-	dc.DrawStringAnchored("差異", float64(marginX)-2, baseY+68, 1, 0.5)
-	dc.DrawStringAnchored("貯水率", float64(marginX)-2, baseY+98, 1, 0.5)
+	dc.DrawStringAnchored("時刻", float64(marginX)-2, blRow1, 1, 0)
+	dc.DrawStringAnchored("差異", float64(marginX)-2, blRow2, 1, 0)
+	dc.DrawStringAnchored("貯水率", float64(marginX)-2, blRow3, 1, 0)
 }
 
 func drawDamFooter(dc *gg.Context, dam *DamData) {
-	y := float64(footerY) + float64(footerHeight)/2
+	centerY := float64(footerY) + float64(footerHeight)/2
 
 	dc.SetRGB(0, 0, 0)
 	face := fontFace(fontRegular, 20)
@@ -369,5 +374,5 @@ func drawDamFooter(dc *gg.Context, dam *DamData) {
 
 	stats := fmt.Sprintf("貯水位: %.2fm    貯水量: %.0f千m³    流入量: %.2fm³/s    放流量: %.2fm³/s",
 		dam.WaterLevel, dam.EffectiveStorage, dam.Inflow, dam.Outflow)
-	dc.DrawStringAnchored(stats, float64(Width)/2, y, 0.5, 0.5)
+	dc.DrawStringAnchored(stats, float64(Width)/2, centeredBaselineY(face, centerY), 0.5, 0)
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/fogleman/gg"
-	"github.com/golang/freetype/truetype"
 	"golang.org/x/image/font"
+	"golang.org/x/image/font/opentype"
 
 	"github.com/kangaechu/m5paper-dashboard/fonts"
 )
@@ -47,7 +47,7 @@ type DailyStorageRate struct {
 	StorageRate float64 `json:"storage_rate"` // percentage
 }
 
-var fontRegular *truetype.Font
+var fontRegular *opentype.Font
 
 func init() {
 	var err error
@@ -57,20 +57,33 @@ func init() {
 	}
 }
 
-func loadFont(name string) (*truetype.Font, error) {
+func loadFont(name string) (*opentype.Font, error) {
 	data, err := fonts.FS.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
-	return truetype.Parse(data)
+	return opentype.Parse(data)
 }
 
-func fontFace(f *truetype.Font, size float64) font.Face {
-	return truetype.NewFace(f, &truetype.Options{
+func fontFace(f *opentype.Font, size float64) font.Face {
+	face, err := opentype.NewFace(f, &opentype.FaceOptions{
 		Size:    size,
 		DPI:     72,
-		Hinting: font.HintingFull,
+		Hinting: font.HintingNone,
 	})
+	if err != nil {
+		panic("failed to create font face: " + err.Error())
+	}
+	return face
+}
+
+// centeredBaselineY returns the baseline Y that visually centers text
+// of the given font.Face around centerY.
+func centeredBaselineY(face font.Face, centerY float64) float64 {
+	m := face.Metrics()
+	ascent := float64(m.Ascent) / 64.0
+	descent := float64(m.Descent) / 64.0
+	return centerY + (ascent-descent)/2
 }
 
 // Dashboard generates the dam dashboard image.


### PR DESCRIPTION
## Summary
- `golang/freetype` のラスタライザーが even-odd fill rule を使うため、「4」等のグリフの交差部分に白抜けが発生していた問題を修正
- `golang.org/x/image/font/opentype` に切り替え（non-zero winding rule で正しく描画）
- opentype のフォントメトリクスの違いによるテキスト位置ずれを修正。`DrawStringAnchored` の `ay=0.5` を廃止し、`centeredBaselineY` ヘルパーで明示的にベースラインを計算するように変更

## Test plan
- [ ] `go run ./cmd/local/` で画像を生成し、「4」の交差部分に白抜けがないことを確認
- [ ] テキストの垂直位置が従来と同等であることを確認（ヘッダー、貯水率、テーブル、フッター）
- [ ] M5Paper 実機で表示を確認