### PR TITLE
Alternate between white and dark background on each wake cycle

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -5,6 +5,8 @@
 
 M5EPD_Canvas canvas(&M5.EPD);
 
+RTC_DATA_ATTR bool useDarkImage = false;
+
 bool connectWiFi();
 bool fetchAndDisplay();
 void drawBatteryBar();
@@ -24,6 +26,8 @@ void setup() {
 
     if (!fetchAndDisplay()) {
         Serial.println("Failed to fetch dashboard image");
+    } else {
+        useDarkImage = !useDarkImage;
     }
 
     WiFi.disconnect(true);
@@ -54,8 +58,17 @@ bool connectWiFi() {
 }
 
 bool fetchAndDisplay() {
+    String url = IMAGE_URL;
+    if (useDarkImage) {
+        int dotIdx = url.lastIndexOf('.');
+        if (dotIdx >= 0) {
+            url = url.substring(0, dotIdx) + "_dark" + url.substring(dotIdx);
+        }
+    }
+    Serial.printf("Fetching: %s\n", url.c_str());
+
     HTTPClient http;
-    http.begin(IMAGE_URL);
+    http.begin(url);
     http.setTimeout(15000);
 
     int httpCode = http.GET();


### PR DESCRIPTION
## Summary
- `RTC_DATA_ATTR bool useDarkImage` で深いスリープを跨いでトグルフラグを保持
- 起動ごとに `IMAGE_URL` から通常版または `_dark` 版の URL を導出して取得
- 表示成功後にフラグを反転し、次回は反対の背景で表示
- 電源断時は `false`（白背景）にリセット

## Test plan
- [ ] `make fw-build` が成功すること
- [ ] シリアルモニタで `Fetching:` の URL が毎サイクル交互に変わることを確認
- [ ] M5Paper 実機で白→黒→白と背景が切り替わることを確認