### PR TITLE
Fix CronJob failing since May: remove obsolete --cache flag

### DIFF
--- a/k8s/cronjob.yaml
+++ b/k8s/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
           containers:
             - name: dashboard
               image: ghcr.io/kangaechu/m5paper-dashboard:latest
-              command: ["/app/m5paper-dashboard", "--output", "/data/dashboard.jpg", "--cache", "/data/dam_history.json"]
+              command: ["/app/m5paper-dashboard", "--output", "/data/dashboard.jpg"]
               envFrom:
                 - configMapRef:
                     name: m5paper-dashboard


### PR DESCRIPTION
## 問題

5月21日以降、ダッシュボードのデータが更新されていなかった（M5Paper が5/21時点の画像を表示し続けていた）。

## 原因

f58cba9 「Replace yearly chart with Tokyo Waterworks PNG」(#177) で `dam_history.json` キャッシュと `--cache` フラグを削除したが、`k8s/cronjob.yaml` は引き続き `--cache /data/dam_history.json` を渡していた。

Go の `flag` パッケージは未定義フラグを受け取ると即座にエラー終了する：

\`\`\`
flag provided but not defined: -cache
\`\`\`

このため 10分間隔の CronJob は画像を生成せず毎回失敗し、データが5月から更新されていなかった。

データ取得元（MLIT ダムデータ・東京都水道局グラフ PNG）は両方とも正常に当日データを返していることを確認済み。

## 修正

CronJob のコマンドから不要な `--cache` フラグを削除。

## 適用後の確認手順

\`\`\`shell
microk8s kubectl apply -k k8s/
microk8s kubectl create job --from=cronjob/m5paper-dashboard manual-test
microk8s kubectl logs job/manual-test
\`\`\`