### PR TITLE
firmware: サンプル設定の画像URLを R2 公開URLに更新

### DIFF
--- a/firmware/include/config.h.sample
+++ b/firmware/include/config.h.sample
@@ -4,8 +4,8 @@
 #define WIFI_SSID     "YOUR_WIFI_SSID"
 #define WIFI_PASSWORD "YOUR_WIFI_PASSWORD"
 
-// Dashboard image URL (CloudFront or S3)
-#define IMAGE_URL     "https://your-cloudfront-domain.cloudfront.net/your-key/dashboard.jpg"
+// Dashboard image URL (Cloudflare R2 public bucket)
+#define IMAGE_URL     "https://pub-xxxxxxxxxxxxxxxx.r2.dev/dashboard.jpg"
 
 // Sleep interval in minutes
 #define SLEEP_MINUTES 60


### PR DESCRIPTION
## 概要

配信方法を R2 アップロード方式に変更したのに合わせて(#190)、ファームウェアのサンプル設定 `config.h.sample` の `IMAGE_URL` を Cloudflare R2 公開バケットの形式に更新します。

## 変更内容

- `IMAGE_URL` のコメントとプレースホルダを CloudFront/S3 から R2 公開URL(`https://pub-xxxx.r2.dev/dashboard.jpg`)形式に変更

## 補足

- 実際の URL は gitignore 済みの `firmware/include/config.h` に記載され、コミットされません(本PRには含まれません)。
- `main.cpp` は `IMAGE_URL` から `_dark` 派生URLを自動生成するため、ダーク版もそのまま取得できます。